### PR TITLE
Small stuff

### DIFF
--- a/gelbooru.py
+++ b/gelbooru.py
@@ -86,8 +86,13 @@ class Gelbooru(commands.Cog):
 
         """look up a picture on gelbooru"""
 
-        if args[0] == "random":
-            tagpool = self.last_search[ctx.message.channel.id].split(" ")
+        if len(args) == 0 or args[0] == "random":
+            tagpool = self.last_search.get(ctx.message.channel.id, None)
+            if tagpool == None:
+                tagpool = self.fallback_tags
+            else:
+                tagpool = tagpool.split(" ");
+            
             candidates = random.sample(tagpool, min(3, len(tagpool)))
             await ctx.message.channel.send("I searched for: {}".format(", ".join(candidates)))
             args = candidates

--- a/gelbooru.py
+++ b/gelbooru.py
@@ -54,6 +54,10 @@ class Gelbooru(commands.Cog):
         Dont know if gelbooru sorts the tags. If they dont, its even more rare. To have the same tags and the tags
         being listed in the same order.
         """
+        if self.last_scored[ctx.message.channel.id] == None:
+            await ctx.message.channel.send("No image to value!")
+            return
+        
         if self.last_scored[ctx.message.channel.id] == self.last_search[ctx.message.channel.id]:
             await ctx.message.channel.send("This image has already been valued!")
             return
@@ -77,7 +81,10 @@ class Gelbooru(commands.Cog):
     async def tags(self, ctx):
 
         """get the tags of the last image"""
-
+        if self.last_search.get(ctx.message.channel.id, None) == None;
+            await ctx.message.channel.send("Nothing was searched yet.")
+            return
+        
         out = "The last image has tags: {}".format(self.last_search[ctx.message.channel.id])
         await ctx.message.channel.send(out)
 

--- a/gelbooru.py
+++ b/gelbooru.py
@@ -103,7 +103,9 @@ class Gelbooru(commands.Cog):
                 tagpool = tagpool.split(" ");
             
             candidates = random.sample(tagpool, min(3, len(tagpool)))
-            await ctx.message.channel.send("I searched for: {}".format(", ".join(candidates)))
+            out = "I searched for: {}".format(", ".join(candidates))
+            out = ct.discordStringEscape(out)
+            await ctx.message.channel.send(out)
             args = candidates
 
         self.last_tags[ctx.message.channel.id] = args #added for dict

--- a/gelbooru.py
+++ b/gelbooru.py
@@ -6,6 +6,7 @@ import json
 import asyncio
 from collections import defaultdict
 import time
+import clean_text as ct
 
 class Gelbooru(commands.Cog):
 
@@ -81,11 +82,12 @@ class Gelbooru(commands.Cog):
     async def tags(self, ctx):
 
         """get the tags of the last image"""
-        if self.last_search.get(ctx.message.channel.id, None) == None;
+        if self.last_search.get(ctx.message.channel.id, None) == None:
             await ctx.message.channel.send("Nothing was searched yet.")
             return
         
         out = "The last image has tags: {}".format(self.last_search[ctx.message.channel.id])
+        out = ct.discordStringEscape(out)
         await ctx.message.channel.send(out)
 
     @commands.command()

--- a/snek2.py
+++ b/snek2.py
@@ -63,7 +63,7 @@ async def on_bane(msg, *args):
 
 async def on_kill(msg, *args):
 
-    match = ct.discordStringEscape(args[0][0])
+    match = ct.discordRemoveUnescapedFormatting(args[0][0])
     out = is_kill(match)
     await msg.channel.send(out)
 

--- a/snek2.py
+++ b/snek2.py
@@ -10,6 +10,7 @@ import getpass
 from sys import exit, argv
 from collections import defaultdict
 import time
+import datetime
 import slot_machine
 from iskill import is_kill
 import re
@@ -229,14 +230,15 @@ async def slots(ctx, *args):
 
 @bot.command()
 async def xmas(ctx):
+    now = datetime.datetime.now()
+    now = datetime.datetime(now.year, now.month, now.day)
+    christmas = datetime.datetime(now.year, 12, 25)
+    if now > christmas: # christmas is already passed. Get the time until next christmas
+        christmas = datetime.datetime(now.year+1, 12, 25)
+    
+    delta = christmas - now
 
-    then = time.mktime(time.strptime("25 Dec 19", "%d %b %y"))
-    now = time.time()
-    delta = then - now
-    days = delta / 86400
-    tosay = int(round(days, 0))
-
-    await ctx.message.channel.send("{} days until Christmas!".format(tosay))
+    await ctx.message.channel.send("{} days until Christmas!".format(delta.days))
 
 
 bot.regexes = {re.compile('''a big [^\?^\s]+\Z'''): on_bane,


### PR DESCRIPTION
- Escaping tags (so underscore wont mess the tags in the chat). Note that this has not been done to the monitor and unmonitor commands
- Changed xmas to use datetime and find the correct xmas date
- snek rate now removes unescaped formatting chars, instead of removing them
- gelbooru exceptions regarding empty argumentlist and rating before searching anything